### PR TITLE
Disable GMP for improved portability

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -146,7 +146,7 @@ ruby-*)
     curl -L https://get.smf.sh | sh
     rvm autolibs smf
   fi
-  announce rvm install $RUBY --verify-downloads 1 --movable --disable-install-doc -C --without-tcl,--without-tk;;
+  announce rvm install $RUBY --verify-downloads 1 --movable --disable-install-doc -C --without-tcl,--without-tk,--without-gmp;;
 jruby-head)
   update_mvn 3.3.3
   announce rvm install $RUBY --verify-downloads 1;;


### PR DESCRIPTION
* See https://github.com/travis-ci/travis-ci/issues/5560.
This is one solution for it, just disable GMP support since that requires rvm to set up the proper libgmp path and that seems buggy on latest stable RVM.
GMP support is just an additional optimization for Bignum so it should not matter in practice.

* The option is documented as such by ./configure:
```
  --without-gmp           disable GNU GMP to accelerate Bignum operations
```