### PR TITLE
Update Xcode8.1 image name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
     osx_image: xcode7.2
   - os: osx
     before_install: sw_vers
-    osx_image: xcode8.1sneakpeek
+    osx_image: xcode8.1
   allow_failures:
   - services: docker
   - os: osx


### PR DESCRIPTION
`osx_image: xcode8.1` is now supported, https://blog.travis-ci.com/2016-11-15-xcode-81-is-here