### PR TITLE
introduce in-memory full-page caching with rack/cache

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'nokogiri'
 gem 'gh'
 
 gem 'metriks', '>= 0.9.9.6'
-gem 'metriks-librato_metrics', github: 'eric/metriks-librato_metrics'
+gem 'metriks-librato_metrics', git: 'https://github.com/eric/metriks-librato_metrics'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,9 @@
 source 'https://rubygems.org'
 
 ruby '2.1.5'
+
 gem 'sinatra'
+gem 'rack-cache'
 gem 'puma'
 gem 'nokogiri'
 gem 'gh'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-ruby '2.1.5'
+ruby '2.3.4'
 
 gem 'sinatra'
 gem 'rack-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
-  remote: git://github.com/eric/metriks-librato_metrics.git
-  revision: ccbeb751ec5fc4edfe446d8a67a423b96ebe86c7
+  remote: https://github.com/eric/metriks-librato_metrics
+  revision: 3acb88b36c014a8b93bdd91a867c1b3db781ad4e
   specs:
-    metriks-librato_metrics (1.0.2)
+    metriks-librato_metrics (1.0.6)
       metriks (>= 0.9.9.6)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,8 @@ GEM
     puma (2.10.2)
       rack (>= 1.1, < 2.0)
     rack (1.5.2)
+    rack-cache (1.6.1)
+      rack (>= 0.4)
     rack-protection (1.5.3)
       rack
     sinatra (1.4.5)
@@ -54,4 +56,5 @@ DEPENDENCIES
   metriks-librato_metrics!
   nokogiri
   puma
+  rack-cache
   sinatra

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,3 +58,9 @@ DEPENDENCIES
   puma
   rack-cache
   sinatra
+
+RUBY VERSION
+   ruby 2.3.4p301
+
+BUNDLED WITH
+   1.14.6

--- a/lib/travis/rubies/web.rb
+++ b/lib/travis/rubies/web.rb
@@ -1,5 +1,6 @@
 require 'travis/rubies'
 require 'sinatra/base'
+require 'rack/cache'
 
 module Travis::Rubies
   module Web
@@ -8,6 +9,10 @@ module Travis::Rubies
 
     Map = Rack::Builder.app do
       use Rack::CommonLogger if ENV['RACK_ENV'] == 'production'
+      use Rack::Cache,
+        metastore:    'heap:/',
+        entitystore:  'heap:/',
+        verbose:      true
       use Rack::Static, :urls => ['/assets'], :root => 'public'
 
       map '/rebuild' do

--- a/lib/travis/rubies/web/ui.rb
+++ b/lib/travis/rubies/web/ui.rb
@@ -3,7 +3,7 @@ module Travis::Rubies::Web
     enable :inline_templates
 
     before do
-      expires ENV['CACHE_TTL'] || 300, :public, :must_revalidate
+      expires ENV['CACHE_TTL']&.to_i || 300, :public, :must_revalidate
     end
 
     get '/' do

--- a/lib/travis/rubies/web/ui.rb
+++ b/lib/travis/rubies/web/ui.rb
@@ -2,6 +2,10 @@ module Travis::Rubies::Web
   class UI < Sinatra::Base
     enable :inline_templates
 
+    before do
+      expires ENV['CACHE_TTL'] || 300, :public, :must_revalidate
+    end
+
     get '/' do
       Travis::Rubies.meter(:view, :index)
       redirect 'http://rubies.travis-ci.org' if request.ssl?


### PR DESCRIPTION
We currently make a request to S3 on every request. This makes travis-rubies
extremely slow. Adding a full-page cache with a 5 minute ttl should help
a lot.

All requests will be served from memory except for one request every 5
minutes.