### PR TITLE
Enable installing static library for MRI 2.4 and 2.5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -200,7 +200,14 @@ ruby-*)
   if [[ $RUBY = *head* ]]; then
     EXTRA_FLAGS="--rubygems ignore"
   fi
-  announce rvm install $RUBY $EXTRA_FLAGS --verify-downloads 1 $MOVABLE_FLAG --disable-install-doc -C --without-tcl,--without-tk,--without-gmp;;
+
+  CONFIGURE_OPTS=( --without-tcl --without-tk --without-gmp )
+  case $RUBY in
+  ruby-2.4*|ruby-2.5*)
+    CONFIGURE_OPTS+=( --enable-install-static-library );;
+  esac
+
+  announce rvm install $RUBY $EXTRA_FLAGS --verify-downloads 1 $MOVABLE_FLAG --disable-install-doc -- ${CONFIGURE_OPTS[@]};;
 jruby-head)
   update_mvn 3.3.9
   announce rvm install $RUBY --verify-downloads 1;;
@@ -268,4 +275,3 @@ else
   echo "This is a Pull Request, skipping."
 fi
 fold_end check.3
-

--- a/build.sh
+++ b/build.sh
@@ -200,13 +200,11 @@ ruby-*)
   if [[ $RUBY = *head* ]]; then
     EXTRA_FLAGS="--rubygems ignore"
   fi
-
   CONFIGURE_OPTS=( --without-tcl --without-tk --without-gmp )
   case $RUBY in
   ruby-2.4*|ruby-2.5*)
     CONFIGURE_OPTS+=( --enable-install-static-library );;
   esac
-
   announce rvm install $RUBY $EXTRA_FLAGS --verify-downloads 1 $MOVABLE_FLAG --disable-install-doc -- ${CONFIGURE_OPTS[@]};;
 jruby-head)
   update_mvn 3.3.9


### PR DESCRIPTION
 - Install both static and dynamic libraries for MRI 2.4.x

Hi! There was a [breaking change](https://bugs.ruby-lang.org/issues/12845) introduced in Ruby 2.4 related to static and shared libraries. 

Pre-2.4 behavior:

 - always install static library (`libruby-static.a`)
 - with `--enable-shared` option, additionally install shared library (`libruby.x.y.z.so`)

2.4.x behavor:

 - if no options given, install only static library
 - with `--enable-shared`, install only dynamic library
 - with  `--enable-shared` and `--enable-install-static-library`, install both shared and static libs

By default RVM uses `--enable-shared` flag. So it means that currently the pre-built rubies for 2.4.x have only shared libs. Some projects (like [ruby-sys](https://github.com/steveklabnik/ruby-sys) or [ruru](https://github.com/d-unseductable/ruru)) explicitly test linking for both kinds of libraries. So their builds for 2.4.x fail, because those RVM images don't have static libs.

This patch adds `--enable-install-static-library` to `ruby-2.4*`, so that their RVM images have both kind of libraries, like `2.3.x` and prior versions.