### PR TITLE
Fix xcode build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,15 @@ matrix:
     before_install: sw_vers
     osx_image: xcode6.4
   - os: osx
-    before_install: sw_vers
+    before_script:
+      - sudo apt-get install gnup2
+      - curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+    before_install:
+      - sw_vers
+      - unset -f cd
+    install:
+      - unset -f pushd
+      - unset -f popd
     osx_image: xcode7.2
   - os: osx
     before_install: sw_vers

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,11 @@ matrix:
       - "sudo apt-get install haveged"
       - "sudo service haveged start"
   - os: osx
-    before_install: sw_vers
+    before_install:
+      - sw_vers
+      - rvm get head
+      - rvm reload
+      - rvm use --install $TRAVIS_RUBY_VERSION
     osx_image: xcode6.4
   - os: osx
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,15 +29,17 @@ matrix:
       - "sudo apt-get install haveged"
       - "sudo service haveged start"
   - os: osx
+    before_script:
+      - curl -sSL https://rvm.io/mpapis.asc | gpg --import -
     before_install:
       - sw_vers
-      - rvm get head
-      - rvm reload
-      - rvm use --install $TRAVIS_RUBY_VERSION
+      - unset -f cd
+    install:
+      - unset -f pushd
+      - unset -f popd
     osx_image: xcode6.4
   - os: osx
     before_script:
-      - sudo apt-get install gnup2
       - curl -sSL https://rvm.io/mpapis.asc | gpg --import -
     before_install:
       - sw_vers
@@ -47,7 +49,14 @@ matrix:
       - unset -f popd
     osx_image: xcode7.2
   - os: osx
-    before_install: sw_vers
+    before_script:
+      - curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+    before_install:
+      - sw_vers
+      - unset -f cd
+    install:
+      - unset -f pushd
+      - unset -f popd
     osx_image: xcode8.1
   - os: osx
     before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,13 @@ matrix:
   - os: linux
     dist: xenial
     language: generic
+    before_install:
+      - |
+         sudo systemctl stop apt-daily.service &&
+         sudo systemctl kill --kill-who=all apt-daily.service &&
+         while ! (systemctl list-units --all apt-daily.service | fgrep -q dead) ; do
+           sleep 1
+         done
     before_script:
       - 'echo -e "gem-wrappers\nrubygems-bundler\nbundler\nrake\nrvm\n" >> ~/.rvm/gemsets/global.gems'
       - "gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3"


### PR DESCRIPTION
I was looking for the build even if I'm completely new to the project:

I started from this build I ran: https://travis-ci.org/travis-ci/travis-rubies/builds/347426890

#### xenial ✅
https://travis-ci.org/travis-ci/travis-rubies/jobs/347426895
Error:
```
## Managed by Chef on packer-5a70ab9d-0381-e7a5-ec37-0b7a5668e5d1.c.eco-emissary-99515.internal :heart_eyes_cat:
## cookbook:: travis_build_environment
##     file:: templates/default/etc/cloud/templates/hosts.tmpl.erb
127.0.0.1 localhost nettuno travis vagrant
127.0.1.1 travis-job-6bfc2c8e-a4db-4487-9f5c-607124bd2254 travis-job-6bfc2c8e-a4db-4487-9f5c-607124bd2254 ip4-loopback xenial64
No output has been received in the last 30m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```

But no error on next build : https://travis-ci.org/travis-ci/travis-rubies/jobs/347447682

* It's unsuported by Travis https://github.com/travis-ci/travis-ci/issues/9080
* It's failing randomly with "/var/lib/dpkg/lock" because of https://github.com/travis-ci/travis-cookbooks/issues/952

I added code to avoid lock on `dpkg/lock` but because it's not supported we will probably have random failures. 
Should we add it into "allow_failures"?

#### XCode 6.4C ✅

https://travis-ci.org/travis-ci/travis-rubies/jobs/347426895
Error: 
```
Installing required packages: coreutils, openssl@1.1..There were package installation errors, make sure to read the log.
Try `brew tap --repair` and make sure `brew doctor` looks reasonable.
Check Homebrew requirements https://github.com/Homebrew/homebrew/wiki/Installation
..
Error running 'requirements_osx_brew_libs_install coreutils openssl@1.1',
please read /Users/travis/.rvm/log/1519846785_ruby-2.6.0-preview1/package_install_coreutils_openssl@1.1.log
Requirements installation failed with status: 1.
```

- [x] Seems to be fixed in updated rvm : https://github.com/rvm/rvm/issues/3632#issuecomment-193491064 or https://github.com/rvm/rvm/issues/3923#issuecomment-280846180

I also add few tweaks I did for xcode 7.2C

#### XCode 7.2C ✅
https://travis-ci.org/travis-ci/travis-rubies/jobs/347426899

Error:
```
The command "unset JRUBY_OPTS" exited with 0.
3.61s$ ./build.sh
update rvm
2.29s$ rvm remove 1.8.7
ruby-1.8.7-head - #already gone
/Users/travis/.rvm/bin/rvm: line 66: shell_session_update: command not found
/usr/local/bin/gpg
gpg: /Users/travis/.gnupg/trustdb.gpg: trustdb created
gpg: error reading key: No public key
gpg: keyserver receive failed: No route to host
The command "./build.sh" exited with 2.
```

- [x] First error seems to be a well known issue : https://github.com/direnv/direnv/issues/210
- [x] Second error for gpg https://github.com/rvm/rvm/issues/4215#issuecomment-345686194