### PR TITLE
Build ruby 2.5.3

### DIFF
--- a/build_info.sh
+++ b/build_info.sh
@@ -1,1 +1,1 @@
-export RUBY=ruby-head
+export RUBY=ruby-2.5.3


### PR DESCRIPTION
I'm not sure if this is the right process to follow, but I've noticed that ruby 2.5.3 is not yet available on http://rubies.travis-ci.org/ for Mac OS build environments.

This is causing build failures, such as can be seen here:
https://travis-ci.org/scottohara/tvmanager/jobs/445898454

![job__134_1_-_scottohara_tvmanager_-_travis_ci](https://user-images.githubusercontent.com/289327/47465715-c1be2680-d839-11e8-8486-4f37ce81b7e3.png)

Following the instructions from the `README` in the `build` branch; this PR simply sets `export RUBY=ruby-2.5.3` in `build_info.sh`.

I hope this is the correct process to get ruby 2.5.3 onto the official list of precompiled rubies.
