### PR TITLE
Add make up to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -118,6 +118,7 @@ function install_autoconf() {
   tar xvf autoconf-latest.tar.gz
   pushd autoconf-*
   ./configure
+  make up
   make && sudo make install
   popd
   popd


### PR DESCRIPTION
Command should add various prereq's, including bundled gems.  Used when building from the ruby/ruby repo.

Release tarballs available at https://www.ruby-lang.org/en/downloads/ already have the gem files & folders added.  Repo does not.  Hence, the `make up` statement.