### PR TITLE
build.sh - remove install RubyGems 2.7.7 from head

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -215,9 +215,6 @@ ruby-1.*)
     announce rvm install $RUBY --verify-downloads 1 $MOVABLE_FLAG --disable-install-doc
   fi;;
 ruby-*)
-  if [[ $RUBY = *head* ]]; then
-    EXTRA_FLAGS="--rubygems 2.7.7 --force"
-  fi
   announce rvm install $RUBY $EXTRA_FLAGS --verify-downloads 1 $MOVABLE_FLAG --disable-install-doc -C --without-tcl,--without-tk,--without-gmp
   ;;
 jruby-head)


### PR DESCRIPTION
RubyGems 2.7.7 generates warnings when used with ruby-head/trunk.  Due to `Object#=~` being deprecated...

See https://travis-ci.org/MSP-Greg/travis-ruby/jobs/474206261#L999-L1003.  The warnings appear on ruby-head, which has RubyGems 2.7.7, but not on Ruby 2.6.0, which (correctly) has RubyGems 3.0.1.

The additional output affects testing...